### PR TITLE
Fix GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+public/rss.xsl linguist-vendored


### PR DESCRIPTION
Mark `public/rss.xsl` as linguist-vendored to remove from language stats.